### PR TITLE
Pinning scanner versions

### DIFF
--- a/.github/workflows/docker.image.yml
+++ b/.github/workflows/docker.image.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Codespell
-        uses: codespell-project/actions-codespell@master
+        uses: codespell-project/actions-codespell@v2.1
         with:
           skip: .git
           check_filenames: true
@@ -46,12 +46,13 @@ jobs:
           # list of files that changed across commits
           fetch-depth: 0
       - name: Lint Code Base
-        uses: super-linter/super-linter@v8
+        uses: super-linter/super-linter@v8.2.0
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_TRIVY: false
+          VALIDATE_BIOME_FORMAT: false
   shiftleft:
     name: shiftleft
     strategy:
@@ -60,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Perform ShiftLeft Scan
-        uses: ShiftLeftSecurity/scan-action@master
+        uses: ShiftLeftSecurity/scan-action@v1.3.0
         env:
           WORKSPACE: ""
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary by Sourcery

Pin scanners in CI workflows to stable versions and disable BIOME lint in super-linter

CI:
- Pin codespell GitHub Action to v2.1
- Pin super-linter to v8.2.0 and disable BIOME lint
- Pin ShiftLeft scan-action to v1.3.0